### PR TITLE
Map props.key to state.intl.locale

### DIFF
--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -7,6 +7,7 @@ const mapStateToProps = (state) => {
   const {intl} = state
   return {
     ...intl,
+    key: intl.locale,
   }
 }
 


### PR DESCRIPTION
See proposed solution to switching locales with react-redux https://github.com/yahoo/react-intl/issues/234#issuecomment-163366518
I tweaked mapStateToProps to set props.key to state.intl.locale so that a re-render occurs when locale is hot swapped.
